### PR TITLE
feat: 상세페이지 UI 수정 및 게시판 Firebase 연동

### DIFF
--- a/src/components/AllBoard/AllBoardEmptyCard.jsx
+++ b/src/components/AllBoard/AllBoardEmptyCard.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { StAllBoardContent, StAllBoardContentBox, StAllBoardEmptyItem, StAllBoardTitleBox } from './styles'
+
+export default function AllBoardEmptyCard() {
+  return (
+<StAllBoardEmptyItem>
+        <StAllBoardContentBox>
+          <StAllBoardTitleBox>
+            <StAllBoardContent>게시물이 없습니다.</StAllBoardContent>
+          </StAllBoardTitleBox>
+        </StAllBoardContentBox>
+    </StAllBoardEmptyItem>
+  )
+}

--- a/src/components/AllBoard/AllBoardEmptyCard.jsx
+++ b/src/components/AllBoard/AllBoardEmptyCard.jsx
@@ -1,14 +1,19 @@
-import React from 'react'
-import { StAllBoardContent, StAllBoardContentBox, StAllBoardEmptyItem, StAllBoardTitleBox } from './styles'
+import React from 'react';
+import {
+  StAllBoardContent,
+  StAllBoardContentBox,
+  StAllBoardEmptyItem,
+  StAllBoardTitleBox,
+} from './styles';
 
 export default function AllBoardEmptyCard() {
   return (
-<StAllBoardEmptyItem>
-        <StAllBoardContentBox>
-          <StAllBoardTitleBox>
-            <StAllBoardContent>게시물이 없습니다.</StAllBoardContent>
-          </StAllBoardTitleBox>
-        </StAllBoardContentBox>
+    <StAllBoardEmptyItem>
+      <StAllBoardContentBox>
+        <StAllBoardTitleBox>
+          <StAllBoardContent>게시물이 없습니다.</StAllBoardContent>
+        </StAllBoardTitleBox>
+      </StAllBoardContentBox>
     </StAllBoardEmptyItem>
-  )
+  );
 }

--- a/src/components/AllBoard/AllBoardIndex.jsx
+++ b/src/components/AllBoard/AllBoardIndex.jsx
@@ -8,7 +8,6 @@ import {
 import { useDispatch, useSelector } from 'react-redux';
 import { changeCategory } from 'redux/modules/selectedCategory';
 
-
 const categories = [
   {
     name: '개인로그',

--- a/src/components/AllBoard/AllBoardList.jsx
+++ b/src/components/AllBoard/AllBoardList.jsx
@@ -3,25 +3,12 @@ import { StAllBoardList, StWriteButton, StWriteButtonBox } from './styles';
 import AllBoardCard from './AllBoardCard';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { initializeApp } from 'firebase/app';
-import { collection, getDocs, getFirestore } from 'firebase/firestore';
+import { collection, getDocs } from 'firebase/firestore';
 import { setBoards } from 'redux/modules/boards';
 import AllBoardEmptyCard from './AllBoardEmptyCard';
+import { db } from 'config/firebase';
 
 export default function AllBoardList() {
-  const firebaseConfig = {
-    apiKey: process.env.REACT_APP_API_KEY,
-    authDomain: process.env.REACT_APP_AUTH_DOMAIN,
-    projectId: process.env.REACT_APP_PROJECT_ID,
-    storageBucket: process.env.REACT_APP_STORAGE_BUCKET,
-    messagingSenderId: process.env.REACT_APP_MESSAGIN_ID,
-    appId: process.env.REACT_APP_APP_ID,
-    measurementId: process.env.REACT_APP_MEASUREMENT_ID,
-  };
-
-  const app = initializeApp(firebaseConfig);
-  const db = getFirestore(app);
-
   const boards = useSelector((store) => store.boards);
   const dispatch = useDispatch();
   const [filteredBoards, setFilteredBoards] = useState([]);
@@ -52,8 +39,8 @@ export default function AllBoardList() {
         </StWriteButton>
       </StWriteButtonBox>
       {filteredBoards.length === 0 ? (
-        <AllBoardEmptyCard/>
-      ) : ( 
+        <AllBoardEmptyCard />
+      ) : (
         filteredBoards.map((data, index) => (
           <AllBoardCard key={index} data={data} />
         ))

--- a/src/components/AllBoard/AllBoardList.jsx
+++ b/src/components/AllBoard/AllBoardList.jsx
@@ -1,17 +1,48 @@
 import React, { useEffect, useState } from 'react';
 import { StAllBoardList, StWriteButton, StWriteButtonBox } from './styles';
 import AllBoardCard from './AllBoardCard';
-import { fakeData } from 'mock/allBoards';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
+import { initializeApp } from 'firebase/app';
+import { collection, getDocs, getFirestore } from 'firebase/firestore';
+import { setBoards } from 'redux/modules/boards';
+import AllBoardEmptyCard from './AllBoardEmptyCard';
 
 export default function AllBoardList() {
-  const [boards, setBoards] = useState(fakeData);
+  const firebaseConfig = {
+    apiKey: process.env.REACT_APP_API_KEY,
+    authDomain: process.env.REACT_APP_AUTH_DOMAIN,
+    projectId: process.env.REACT_APP_PROJECT_ID,
+    storageBucket: process.env.REACT_APP_STORAGE_BUCKET,
+    messagingSenderId: process.env.REACT_APP_MESSAGIN_ID,
+    appId: process.env.REACT_APP_APP_ID,
+    measurementId: process.env.REACT_APP_MEASUREMENT_ID,
+  };
+
+  const app = initializeApp(firebaseConfig);
+  const db = getFirestore(app);
+
+  const boards = useSelector((store) => store.boards);
+  const dispatch = useDispatch();
+  const [filteredBoards, setFilteredBoards] = useState([]);
   const selectedCategory = useSelector((store) => store.selectedCategory);
 
   useEffect(() => {
-    setBoards(fakeData.filter((board) => board.category === selectedCategory));
-  }, [selectedCategory]);
+    getDocs(collection(db, 'boards'))
+      .then((res) => {
+        return res.docs.map((doc) => doc.data());
+      })
+      .then((data) => {
+        dispatch(setBoards(data));
+      });
+  }, []);
+
+  useEffect(() => {
+    if (!boards) return;
+    setFilteredBoards(
+      boards.filter((board) => board.category === selectedCategory),
+    );
+  }, [selectedCategory, boards]);
 
   return (
     <StAllBoardList>
@@ -20,9 +51,13 @@ export default function AllBoardList() {
           <Link to="/boards/new">글쓰기</Link>
         </StWriteButton>
       </StWriteButtonBox>
-      {boards.map((data, index) => (
-        <AllBoardCard key={index} data={data} />
-      ))}
+      {filteredBoards.length === 0 ? (
+        <AllBoardEmptyCard/>
+      ) : ( 
+        filteredBoards.map((data, index) => (
+          <AllBoardCard key={index} data={data} />
+        ))
+      )}
     </StAllBoardList>
   );
 }

--- a/src/components/AllBoard/styles.js
+++ b/src/components/AllBoard/styles.js
@@ -102,7 +102,6 @@ export const StAllBoardEmptyItem = styled.div`
   }
 `;
 
-
 export const StAllBoardNameBox = styled.div`
   display: flex;
   flex-direction: row;

--- a/src/components/AllBoard/styles.js
+++ b/src/components/AllBoard/styles.js
@@ -75,6 +75,34 @@ export const StAllBoardItem = styled.div`
   }
 `;
 
+export const StAllBoardEmptyItem = styled.div`
+  background-color: ${COLORS.itembgColor};
+  color: black;
+  margin-bottom: 40px;
+  margin-left: 50px;
+  padding: 20px;
+  width: 900px;
+  border-radius: 30px;
+  height: 300px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  @media only screen and (max-width: 1200px) {
+    width: 120%;
+    margin: 0;
+  }
+  @media only screen and (max-width: 900px) {
+    width: 140%;
+    margin: 0;
+  }
+  @media only screen and (max-width: 768px) {
+    width: 100%;
+    margin: 0;
+  }
+`;
+
+
 export const StAllBoardNameBox = styled.div`
   display: flex;
   flex-direction: row;

--- a/src/components/BoardDetail/BoardDetailContent.jsx
+++ b/src/components/BoardDetail/BoardDetailContent.jsx
@@ -1,6 +1,13 @@
 import React from 'react';
 
-import { StImg, StContent, StTitle, StAllContent, StBtn } from './styles';
+import {
+  StImg,
+  StContent,
+  StTitle,
+  StAllContent,
+  StBtn,
+  StAllContentBox,
+} from './styles';
 import { MdDeleteForever } from 'react-icons/md';
 import { FaGithub } from 'react-icons/fa';
 
@@ -22,9 +29,9 @@ export default function BoardDetailContent() {
     <>
       {dummyData.map((data) => {
         return (
-          <div key={data.uid}>
+          <StAllContentBox key={data.uid}>
             <StAllContent>
-              <StImg src={data.img} alt="이미지" />
+              <StImg $src={data.img} />
               <StTitle>{data.title}</StTitle>
               <StContent>{data.content}</StContent>
             </StAllContent>
@@ -32,7 +39,7 @@ export default function BoardDetailContent() {
               <FaGithub size="30" />
               <MdDeleteForever size="30" />
             </StBtn>
-          </div>
+          </StAllContentBox>
         );
       })}
     </>

--- a/src/components/BoardDetail/styles.js
+++ b/src/components/BoardDetail/styles.js
@@ -8,49 +8,63 @@ export const StBoardDetailMain = styled.div`
   align-items: center;
 `;
 
-export const StImg = styled.img`
-  width: 100%;
-  height: 450px;
-
+export const StImg = styled.div`
+  background-image: url(${(props) => props.$src});
+  width: 500px;
+  height: 500px;
   border-radius: 20px;
+  background-size: cover;
+  background-position: center;
+  @media only screen and (max-width: 1300px) {
+    width: 400px;
+  }
+  @media only screen and (max-width: 1050px) {
+    width: 280px;
+  }
+`;
+
+export const StAllContentBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 70%;
+  justify-content: center;
+  padding: 20px;
 `;
 
 export const StAllContent = styled.div`
   height: 700px;
-  width: 100%;
+  width: 65%;
   display: flex;
   align-items: center;
   flex-direction: column;
   justify-content: space-evenly;
-  padding: 4%;
-
+  padding: 20px;
   border-radius: 20px;
-
   background-color: ${COLORS.itembgColor};
 `;
 
 export const StContent = styled.p`
   width: 100%;
   text-align: justify;
-  padding: 2%;
+  padding: 15px;
 `;
 
 export const StTitle = styled.p`
-  padding: 2%;
+  padding: 15px;
   font-size: larger;
 `;
 
 export const StBtn = styled.button`
-  width: 100%;
+  width: 65%;
   display: flex;
   justify-content: flex-end;
-  margin-top: 3%;
+  margin-top: 40px;
 `;
 
 export const StGoListBtn = styled.button`
-  width: 100%;
-  margin-top: 3%;
-  padding: 1%;
+  width: 45%;
+  padding: 20px;
   border-radius: 7px;
   font-size: medium;
   background-color: ${COLORS.itembgColor};

--- a/src/redux/config/configStore.js
+++ b/src/redux/config/configStore.js
@@ -1,12 +1,13 @@
 import { createStore, combineReducers } from 'redux';
 import userReducer from 'redux/modules/User';
+import boards from 'redux/modules/boards';
 import selectedCategory from 'redux/modules/selectedCategory';
 
 const rootReducer = combineReducers({
   userReducer,
   selectedCategory,
+  boards,
 });
 const store = createStore(rootReducer);
 
 export default store;
- 

--- a/src/redux/modules/boards.js
+++ b/src/redux/modules/boards.js
@@ -1,0 +1,22 @@
+const SET_BOARDS = 'SET_BOARDS';
+
+export const initialState = [];
+
+export const setBoards = (boards) => ({
+  type: SET_BOARDS,
+  payload: {
+    boards,
+  },
+});
+
+const boards = (state = initialState, action) => {
+  const { type, payload } = action;
+  switch (type) {
+    case SET_BOARDS:
+      return payload.boards;
+    default:
+      return state;
+  }
+};
+
+export default boards;


### PR DESCRIPTION
## 작업 내용

- 상세 페이지

1. 상세 페이지 크기 수정
2. 게시물 이미지 반응형 구현(미디어쿼리 사용)

- 게시판

1. firebase 연결(firebase data를 게시물로 연동)
2. 조건부 게시물 구현(게시물이 없을 때 게시물이 없다라는 안내카드 보여주기) : redux 사용

## Close issue(s)

- #27
- #25