### PR TITLE
feat: 로그인 모달창 UI

### DIFF
--- a/src/components/Auth/AuthModal.jsx
+++ b/src/components/Auth/AuthModal.jsx
@@ -5,14 +5,8 @@ import AuthStartScreen from './AuthStartScreen';
 import EmailLoginScreen from './EmailLoginScreen';
 import SignUpScreen from './SignUpScreen';
 
-const componentList = {
-  START: 'start',
-  EMAIL: 'email',
-  SIGNUP: 'signup',
-};
-
 export default function AuthModal({ onClose }) {
-  const [currentComponent, setCurrentComponent] = useState(componentList.START);
+  const [currentComponent, setCurrentComponent] = useState('start');
   const toggleCurrentComponent = (componentName) =>
     setCurrentComponent(componentName);
 
@@ -23,11 +17,11 @@ export default function AuthModal({ onClose }) {
 
   const renderComponent = useMemo(() => {
     switch (currentComponent) {
-      case componentList.START:
+      case 'start':
         return <AuthStartScreen toggleComponent={toggleCurrentComponent} />;
-      case componentList.EMAIL:
+      case 'email':
         return <EmailLoginScreen toggleComponent={toggleCurrentComponent} />;
-      case componentList.SIGNUP:
+      case 'signup':
         return <SignUpScreen toggleComponent={toggleCurrentComponent} />;
       default:
         return;

--- a/src/components/Auth/AuthStartScreen.jsx
+++ b/src/components/Auth/AuthStartScreen.jsx
@@ -21,7 +21,9 @@ export default function AuthStartScreen({ toggleComponent }) {
           <FaGithub size="1rem" />
           깃헙으로 3초만에 시작하기
         </StButton>
-        <StButton onClick={toggleComponent}>이메일로 시작하기</StButton>
+        <StButton onClick={() => toggleComponent('email')}>
+          이메일로 시작하기
+        </StButton>
       </div>
     </>
   );

--- a/src/components/Auth/EmailLoginScreen.jsx
+++ b/src/components/Auth/EmailLoginScreen.jsx
@@ -37,11 +37,16 @@ export default function EmailLoginScreen({ toggleComponent }) {
         <div>
           <span>
             아직 가입하지 않았나요?
-            <StGoToSignUpBtn>회원가입하기</StGoToSignUpBtn>
+            <StGoToSignUpBtn
+              onClick={() => toggleComponent('signup')}
+              type="button"
+            >
+              회원가입하기
+            </StGoToSignUpBtn>
           </span>
         </div>
       </StSignForm>
-      <StGoToBackBtn onClick={toggleComponent}>
+      <StGoToBackBtn onClick={() => toggleComponent('start')}>
         <FaArrowLeft />
         뒤로
       </StGoToBackBtn>

--- a/src/components/Auth/SignUpScreen.jsx
+++ b/src/components/Auth/SignUpScreen.jsx
@@ -1,5 +1,66 @@
 import React from 'react';
+import { StGoToBackBtn, StSignForm } from './styles';
+import { FaArrowLeft } from 'react-icons/fa';
 
-export default function SignUpScreen() {
-  return <></>;
+export default function SignUpScreen({ toggleComponent }) {
+  const handleSubmit = (e) => {
+    e.preventDefault();
+  };
+
+  return (
+    <>
+      <header>
+        <h2>회원가입</h2>
+      </header>
+      <StSignForm onSubmit={handleSubmit}>
+        <div>
+          <label htmlFor="nickname">닉네임</label>
+          <input
+            id="nickname"
+            type="text"
+            autoComplete="nickname"
+            placeholder="닉네임 입력"
+            required
+          />
+        </div>
+        <div>
+          <label htmlFor="email">이메일</label>
+          <input
+            id="email"
+            type="text"
+            autoComplete="username"
+            placeholder="이메일 입력"
+            required
+          />
+        </div>
+        <div>
+          <label htmlFor="password">비밀번호</label>
+          <input
+            id="password"
+            type="password"
+            autoComplete="current-password"
+            placeholder="비밀번호 입력"
+            required
+          />
+        </div>
+        <div>
+          <label htmlFor="password-check">비밀번호</label>
+          <input
+            id="password-check"
+            type="password"
+            autoComplete="current-password"
+            placeholder="비밀번호 확인"
+            required
+          />
+        </div>
+        <div>
+          <button type="submit">가입하기</button>
+        </div>
+      </StSignForm>
+      <StGoToBackBtn onClick={() => toggleComponent('email')}>
+        <FaArrowLeft />
+        뒤로
+      </StGoToBackBtn>
+    </>
+  );
 }


### PR DESCRIPTION
## 작업 내용
- 로그인한 사용자가 없을 때 헤더의 로그인 클릭하면 모달창 띄우기
- 로그인 모달창 UI
- 버튼을 클릭하면 각 컴포넌트로 이동

## TODO LIST
- 회원가입 firebase 연동
- 로그인, 회원가입 로직 추가
- 유효성 검사

|모달 첫화면| 이메일 로그인 | 회원가입|
|--|--|--|
|<img src="https://github.com/nbcamp-a3/my-best-project/assets/82589401/3082f8cd-1b5a-49fb-aeef-d1ea8043027a" />| <img src="https://github.com/nbcamp-a3/my-best-project/assets/82589401/83565115-0950-4215-b2eb-49ca04ba0020"/>| <img src="https://github.com/nbcamp-a3/my-best-project/assets/82589401/5e94ee9c-77ca-4af9-ad56-74dfda1779cf" /> |

![로그인,회원가입 UI](https://github.com/nbcamp-a3/my-best-project/assets/82589401/7ed7e355-77f4-4594-84fe-c1dc33229893)

## Close issue(s)

- #19 
