### PR TITLE
feat: CRUD 중 R, D구현

### DIFF
--- a/src/components/AllBoard/AllBoardCard.jsx
+++ b/src/components/AllBoard/AllBoardCard.jsx
@@ -36,7 +36,7 @@ export default function AllBoardCard({ data }) {
           <StAllBoardLikedButton>❤️</StAllBoardLikedButton>
         </StTimeBox>
       </StAllBoardNameBox>
-      <Link to={`/boards/${data.uid}`}>
+      <Link to={`/boards/${data.id}`}>
         <StAllBoardContentBox>
           <StAllBoardTitleBox>
             <StAllBoarTitle>{data.title}</StAllBoarTitle>

--- a/src/components/AllBoard/AllBoardList.jsx
+++ b/src/components/AllBoard/AllBoardList.jsx
@@ -17,7 +17,12 @@ export default function AllBoardList() {
   useEffect(() => {
     getDocs(collection(db, 'boards'))
       .then((res) => {
-        return res.docs.map((doc) => doc.data());
+        return res.docs.map((doc) => {
+          return {
+            id: doc.id,
+            ...doc.data(),
+          };
+        });
       })
       .then((data) => {
         dispatch(setBoards(data));

--- a/src/components/AllBoard/AllBoardList.jsx
+++ b/src/components/AllBoard/AllBoardList.jsx
@@ -34,9 +34,9 @@ export default function AllBoardList() {
   return (
     <StAllBoardList>
       <StWriteButtonBox>
-        <StWriteButton>
-          <Link to="/boards/new">글쓰기</Link>
-        </StWriteButton>
+        <Link to="/boards/new">
+          <StWriteButton>글쓰기</StWriteButton>
+        </Link>
       </StWriteButtonBox>
       {filteredBoards.length === 0 ? (
         <AllBoardEmptyCard />

--- a/src/components/BoardDetail/BoardDetailContent.jsx
+++ b/src/components/BoardDetail/BoardDetailContent.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import {
   StImg,
@@ -10,38 +10,43 @@ import {
 } from './styles';
 import { MdDeleteForever } from 'react-icons/md';
 import { FaGithub } from 'react-icons/fa';
+import { useNavigate, useParams } from 'react-router-dom';
+import { db } from 'config/firebase';
+import { deleteDoc, doc, getDoc } from 'firebase/firestore';
 
 export default function BoardDetailContent() {
-  const dummyData = [
-    {
-      createdAt: '2023-11-03T02:07:09.423Z',
-      email: 'abc123@gmail.com',
-      photoURL:
-        'https://files.slack.com/files-pri/T043597JK8V-F066H5AP9AS/avatar.png',
-      title: '삼의맹세',
-      content:
-        'JENNIE Vitae recusandae tenetur debitis impedit ut dolorem atque reprehenderit magnam. Cum dolor magnam commodi qui perferendis. Vel temporibus soluta. Eum delectus blanditiis. Neque dicta non quod ex. Maiores aspernatur fuga reprehenderit a magni eaque fuga voluptatum hic.',
-      img: 'https://images.unsplash.com/photo-1700540291181-2d7be661477e?w=700&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxlZGl0b3JpYWwtZmVlZHw0fHx8ZW58MHx8fHx8',
-      uid: '0',
-    },
-  ];
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [data, setData] = useState({});
+
+  useEffect(() => {
+    const boardRef = doc(db, 'boards', id);
+    getDoc(boardRef).then((res) => {
+      setData(res.data());
+    });
+  }, [id]);
+
+  const clickDelete = async () => {
+    if (!window.confirm('삭제하시겠습니까?')) return;
+    const boardRef = doc(db, 'boards', id);
+    deleteDoc(boardRef).then(() => {
+      alert('삭제되었습니다.');
+      navigate('/boards');
+    });
+  };
+
+  if (!data) return null;
   return (
-    <>
-      {dummyData.map((data) => {
-        return (
-          <StAllContentBox key={data.uid}>
-            <StAllContent>
-              <StImg $src={data.img} />
-              <StTitle>{data.title}</StTitle>
-              <StContent>{data.content}</StContent>
-            </StAllContent>
-            <StBtn>
-              <FaGithub size="30" />
-              <MdDeleteForever size="30" />
-            </StBtn>
-          </StAllContentBox>
-        );
-      })}
-    </>
+    <StAllContentBox key={data.uid}>
+      <StAllContent>
+        <StImg $src={data.img} />
+        <StTitle>{data.title}</StTitle>
+        <StContent>{data.content}</StContent>
+      </StAllContent>
+      <StBtn>
+        <FaGithub size="30" />
+        <MdDeleteForever size="30" onClick={() => clickDelete()} />
+      </StBtn>
+    </StAllContentBox>
   );
 }

--- a/src/components/BoardDetail/styles.js
+++ b/src/components/BoardDetail/styles.js
@@ -64,9 +64,18 @@ export const StBtn = styled.button`
 `;
 
 export const StGoListBtn = styled.button`
-  width: 45%;
+  width: 100%;
   padding: 20px;
   border-radius: 7px;
   font-size: medium;
   background-color: ${COLORS.itembgColor};
+  cursor: pointer;
+`;
+
+export const StGoListBtnBox = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  width: 65%;
 `;

--- a/src/components/BoardDetail/styles.js
+++ b/src/components/BoardDetail/styles.js
@@ -60,6 +60,7 @@ export const StBtn = styled.button`
   display: flex;
   justify-content: flex-end;
   margin-top: 40px;
+  cursor: pointer;
 `;
 
 export const StGoListBtn = styled.button`

--- a/src/pages/BoardDetail.jsx
+++ b/src/pages/BoardDetail.jsx
@@ -1,12 +1,21 @@
 import React from 'react';
 import BoardDetailContent from 'components/BoardDetail/BoardDetailContent';
-import { StBoardDetailMain, StGoListBtn } from 'components/BoardDetail/styles';
+import {
+  StBoardDetailMain,
+  StGoListBtn,
+  StGoListBtnBox,
+} from 'components/BoardDetail/styles';
+import { Link } from 'react-router-dom';
 
 export default function BoardDetail() {
   return (
     <StBoardDetailMain>
       <BoardDetailContent />
-      <StGoListBtn>목록으로</StGoListBtn>
+      <StGoListBtnBox>
+        <Link to="/boards">
+          <StGoListBtn>목록으로</StGoListBtn>
+        </Link>
+      </StGoListBtnBox>
     </StBoardDetailMain>
   );
 }


### PR DESCRIPTION
## 작업 내용

- CRUD 중 Delete 구현
- 목록 누르면 카드의 카테고리 별로 각각 이동 
- 게시물 누르면 상세페이지로 이동(Authentication에서 제공하는 uid 이용)

![삭제시연](https://github.com/nbcamp-a3/my-best-project/assets/145653599/a54110c6-3ce2-4385-947b-58e8d6d29d46)


## Close issue(s)

- #29
