### PR TITLE
fix: 마이 페이지 프로필 수정 url에서 로그아웃하면 alert창 두 번 뜨는 문제

### DIFF
--- a/src/pages/ProtectedRoute.jsx
+++ b/src/pages/ProtectedRoute.jsx
@@ -1,17 +1,27 @@
-import { useLoggedIn } from 'hooks/useAuth';
 import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLoggedIn } from 'hooks/useAuth';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 export default function ProtectedRoute({ children }) {
+  const location = useLocation();
   const { loginState } = useLoggedIn();
   const navigate = useNavigate();
 
   useEffect(() => {
     if (!loginState) {
       window.alert('로그인이 필요합니다.');
+
+      if (location.pathname.includes('/mypage')) {
+        return navigate('/');
+      }
+
+      if (location.pathname.includes('/boards')) {
+        return navigate('/boards');
+      }
+
       navigate(-1);
     }
-  }, [loginState, navigate]);
+  }, [loginState, navigate, location]);
 
   return <>{loginState && children}</>;
 }


### PR DESCRIPTION
## 작업 내용

- `mypage/edit` 경로에서 로그아웃하면 -> alert창 -> `navigate(-1)` -> `mypage/` 이동 -> alert -> `navigate(-1)`
- 조건부로 리다이렉트 되도록 변경

```jsx
if (location.pathname.includes('/mypage')) {
  return navigate('/');

if (location.pathname.includes('/boards')) {
  return navigate('/boards');
}
```

## Close issue(s)

- #59 
